### PR TITLE
Optimize --production installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
 		"covert": "1.0.0",
 		"jscs": "~1.7.3"
 	},
+	"files": [
+		"index.js"
+	],
 	"testling": {
 		"files": "test/index.js",
 		"browsers": [


### PR DESCRIPTION
Via `npm install --production`, only index.js and standard NPM files (readme.md, package.json) will be installed.

Please `npm publish` if/when changes are accepted.
