### PR TITLE
Remove use of function-bind package

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -2,14 +2,17 @@
 
 // modified from https://github.com/es-shims/es6-shim
 var keys = require('object-keys');
-var bind = require('function-bind');
 var canBeObject = function (obj) {
 	return typeof obj !== 'undefined' && obj !== null;
 };
 var hasSymbols = require('./hasSymbols')();
 var toObject = Object;
-var push = bind.call(Function.call, Array.prototype.push);
-var propIsEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
+var push = function (arr, item) {
+	return Array.prototype.push.call(arr, item);
+};
+var propIsEnumerable = function (obj, prop) {
+	return Object.prototype.propertyIsEnumerable.call(obj, prop);
+};
 
 module.exports = function assign(target, source1) {
 	if (!canBeObject(target)) { throw new TypeError('target must be an object'); }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"shim"
 	],
 	"dependencies": {
-		"function-bind": "^1.0.2",
 		"object-keys": "^1.0.9",
 		"define-properties": "^1.1.2"
 	},
@@ -80,4 +79,3 @@
 		"node": ">= 0.4"
 	}
 }
-


### PR DESCRIPTION
The `function-bind` package is using `eval`, which breaks Content Security Policy rules. This is preventing us from using `object.assign` indirectly.

Does removing this dependency make sense to you?