### PR TITLE
Remove dependency on function-bind

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -2,14 +2,18 @@
 
 // modified from https://github.com/es-shims/es6-shim
 var keys = require('object-keys');
-var bind = require('function-bind');
 var canBeObject = function (obj) {
 	return typeof obj !== 'undefined' && obj !== null;
 };
+var bind = function (fn, thisArg) {
+	return function () {
+		return fn.apply(thisArg, arguments);
+	};
+};
 var hasSymbols = require('has-symbols/shams')();
 var toObject = Object;
-var push = bind.call(Function.call, Array.prototype.push);
-var propIsEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
+var push = bind(Function.call, Array.prototype.push);
+var propIsEnumerable = bind(Function.call, Object.prototype.propertyIsEnumerable);
 var originalGetSymbols = hasSymbols ? Object.getOwnPropertySymbols : null;
 
 module.exports = function assign(target, source1) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"shim"
 	],
 	"dependencies": {
-		"function-bind": "^1.1.0",
 		"object-keys": "^1.0.11",
 		"define-properties": "^1.1.2",
 		"has-symbols": "^1.0.0"
@@ -79,4 +78,3 @@
 		"node": ">= 0.4"
 	}
 }
-


### PR DESCRIPTION
Hi!

`function-bind` is a very good implementation that follows the spec very closely. The problem is that in order to follow the spec it must use `eval` to ensure the bound function has a correct `length` property. This is an issue in environments that use Content Security Policy to block `eval`.

However, `object.assign` doesn't really need that behavior, or anything related to `new` for that matter, so a minimal `bind` implementation is enough for it. This PR removes the dependency on `function-bind` and replaces it with a very naive `bind` function.

Thoughts?