### PR TITLE
[New] add `auto` entry point

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('./shim')();

--- a/package.json
+++ b/package.json
@@ -46,15 +46,15 @@
 		"object-keys": "^1.0.11"
 	},
 	"devDependencies": {
-		"@es-shims/api": "^1.3.0",
+		"@es-shims/api": "^2.1.1",
 		"@ljharb/eslint-config": "^12.2.1",
-		"browserify": "^14.4.0",
+		"browserify": "^14.5.0",
 		"covert": "^1.1.0",
-		"eslint": "^4.6.1",
+		"eslint": "^4.13.1",
 		"for-each": "^0.3.2",
 		"is": "^3.2.1",
 		"jscs": "^3.0.7",
-		"nsp": "^2.8.0",
+		"nsp": "^3.1.0",
 		"tape": "^4.8.0"
 	},
 	"testling": {


### PR DESCRIPTION
support [es-shim-api](https://github.com/es-shims/es-shim-api) auto shim feature

`require('foo/auto')` will automatically invoke the `shim` method.