### PR TITLE
Upgrade object-keys dependency to 1.0.12

### DIFF
--- a/hasSymbols.js
+++ b/hasSymbols.js
@@ -14,10 +14,12 @@ module.exports = function hasSymbols() {
 	if (Object.prototype.toString.call(sym) !== '[object Symbol]') { return false; }
 	if (Object.prototype.toString.call(symObj) !== '[object Symbol]') { return false; }
 
-	// temp disabled per https://github.com/ljharb/object.assign/issues/17
-	// if (sym instanceof Symbol) { return false; }
-	// temp disabled per https://github.com/WebReflection/get-own-property-symbols/issues/4
-	// if (!(symObj instanceof Symbol)) { return false; }
+	/*
+	 * temp disabled per https://github.com/ljharb/object.assign/issues/17
+	 * if (sym instanceof Symbol) { return false; }
+	 * temp disabled per https://github.com/WebReflection/get-own-property-symbols/issues/4
+	 * if (!(symObj instanceof Symbol)) { return false; }
+	 */
 
 	var symVal = 42;
 	obj[sym] = symVal;

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
 		"shim"
 	],
 	"dependencies": {
-		"define-properties": "^1.1.2",
+		"define-properties": "^1.1.3",
 		"function-bind": "^1.1.1",
 		"has-symbols": "^1.0.0",
-		"object-keys": "^1.0.11"
+		"object-keys": "^1.0.12"
 	},
 	"devDependencies": {
 		"@es-shims/api": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -47,15 +47,15 @@
 	},
 	"devDependencies": {
 		"@es-shims/api": "^2.1.2",
-		"@ljharb/eslint-config": "^12.2.1",
-		"browserify": "^16.2.2",
+		"@ljharb/eslint-config": "^13.0.0",
+		"browserify": "^16.2.3",
 		"covert": "^1.1.0",
-		"eslint": "^4.19.1",
+		"eslint": "^5.9.0",
 		"for-each": "^0.3.3",
 		"is": "^3.2.1",
 		"jscs": "^3.0.7",
 		"nsp": "^3.2.1",
-		"tape": "^4.9.0"
+		"tape": "^4.9.1"
 	},
 	"testling": {
 		"files": "test/index.js",

--- a/polyfill.js
+++ b/polyfill.js
@@ -6,8 +6,10 @@ var lacksProperEnumerationOrder = function () {
 	if (!Object.assign) {
 		return false;
 	}
-	// v8, specifically in node 4.x, has a bug with incorrect property enumeration order
-	// note: this does not detect the bug unless there's 20 characters
+	/*
+	 * v8, specifically in node 4.x, has a bug with incorrect property enumeration order
+	 * note: this does not detect the bug unless there's 20 characters
+	 */
 	var str = 'abcdefghijklmnopqrst';
 	var letters = str.split('');
 	var map = {};
@@ -26,8 +28,10 @@ var assignHasPendingExceptions = function () {
 	if (!Object.assign || !Object.preventExtensions) {
 		return false;
 	}
-	// Firefox 37 still has "pending exception" logic in its Object.assign implementation,
-	// which is 72% slower than our shim, and Firefox 40's native implementation.
+	/*
+	 * Firefox 37 still has "pending exception" logic in its Object.assign implementation,
+	 * which is 72% slower than our shim, and Firefox 40's native implementation.
+	 */
 	var thrower = Object.preventExtensions({ 1: 2 });
 	try {
 		Object.assign(thrower, 'xy');

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,6 @@
 {
 	"rules": {
+		"max-lines-per-function": 0,
 		"max-statements-per-line": [2, { "max": 3 }],
 		"no-magic-numbers": 0,
 		"object-curly-newline": 0,

--- a/test/native.js
+++ b/test/native.js
@@ -30,8 +30,10 @@ test('native', function (t) {
 	// v8 in node 0.8 and 0.10 have non-enumerable string properties
 	var stringCharsAreEnumerable = isEnumerable.call('xy', 0);
 	t.test('when Object.assign is present and has pending exceptions', { skip: !stringCharsAreEnumerable || !Object.preventExtensions }, function (st) {
-		// Firefox 37 still has "pending exception" logic in its Object.assign implementation,
-		// which is 72% slower than our shim, and Firefox 40's native implementation.
+		/*
+		 * Firefox 37 still has "pending exception" logic in its Object.assign implementation,
+		 * which is 72% slower than our shim, and Firefox 40's native implementation.
+		 */
 		var thrower = Object.preventExtensions({ 1: '2' });
 		var error;
 		try { Object.assign(thrower, 'xy'); } catch (e) { error = e; }

--- a/test/shimmed.js
+++ b/test/shimmed.js
@@ -33,8 +33,10 @@ test('shimmed', function (t) {
 	// v8 in node 0.8 and 0.10 have non-enumerable string properties
 	var stringCharsAreEnumerable = isEnumerable.call('xy', 0);
 	t.test('when Object.assign is present and has pending exceptions', { skip: !stringCharsAreEnumerable || !Object.preventExtensions }, function (st) {
-		// Firefox 37 still has "pending exception" logic in its Object.assign implementation,
-		// which is 72% slower than our shim, and Firefox 40's native implementation.
+		/*
+		 * Firefox 37 still has "pending exception" logic in its Object.assign implementation,
+		 * which is 72% slower than our shim, and Firefox 40's native implementation.
+		 */
 		var thrower = Object.preventExtensions({ 1: '2' });
 		var error;
 		try { Object.assign(thrower, 'xy'); } catch (e) { error = e; }


### PR DESCRIPTION
The `object-keys` dependency was [recently updated](https://github.com/ljharb/object-keys/blob/master/CHANGELOG.md#1012--2018-06-18) to avoid accessing `window.applicationCache`. This pull request updates the dependency here to resolve the issue in other [dependencies](https://github.com/shellscape/loglevelnext/blob/master/package.json#L53) that bundle `object.assign` in their distribution causing issues in the latest chrome.

Please publish if the changes are merged. Thanks!