### PR TITLE
[Tests] ses-compat - create polyfill wrapper if using intrinsic Object.assign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ import:
  - ljharb/travis-ci:node/pretest.yml
  - ljharb/travis-ci:node/posttest.yml
  - ljharb/travis-ci:node/coverage.yml
+script:
+   - 'if [ -n "${SES-}" ]; then npm run test:ses; fi'
 matrix:
   allow_failures:
     - env: COVERAGE=true
+  include:
+    - node_js: "14"
+      env: SES=true
+    - node_js: "13"
+      env: SES=true
+    - node_js: "12"
+      env: SES=true

--- a/implementation.js
+++ b/implementation.js
@@ -2,14 +2,14 @@
 
 // modified from https://github.com/es-shims/es6-shim
 var keys = require('object-keys');
-var bind = require('function-bind');
 var canBeObject = function (obj) {
 	return typeof obj !== 'undefined' && obj !== null;
 };
 var hasSymbols = require('has-symbols/shams')();
+var callBound = require('es-abstract/helpers/callBound');
 var toObject = Object;
-var push = bind.call(Function.call, Array.prototype.push);
-var propIsEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
+var $push = callBound('Array.prototype.push');
+var $propIsEnumerable = callBound('Object.prototype.propertyIsEnumerable');
 var originalGetSymbols = hasSymbols ? Object.getOwnPropertySymbols : null;
 
 // eslint-disable-next-line no-unused-vars
@@ -25,15 +25,15 @@ module.exports = function assign(target, source1) {
 			syms = getSymbols(source);
 			for (i = 0; i < syms.length; ++i) {
 				key = syms[i];
-				if (propIsEnumerable(source, key)) {
-					push(props, key);
+				if ($propIsEnumerable(source, key)) {
+					$push(props, key);
 				}
 			}
 		}
 		for (i = 0; i < props.length; ++i) {
 			key = props[i];
 			value = source[key];
-			if (propIsEnumerable(source, key)) {
+			if ($propIsEnumerable(source, key)) {
 				objTarget[key] = value;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -1,17 +1,22 @@
 'use strict';
 
 var defineProperties = require('define-properties');
+var callBind = require('es-abstract/helpers/callBind');
 
 var implementation = require('./implementation');
 var getPolyfill = require('./polyfill');
 var shim = require('./shim');
 
-var polyfill = getPolyfill();
+var polyfill = callBind.apply(getPolyfill());
+// eslint-disable-next-line no-unused-vars
+var bound = function assign(target, source1) {
+	return polyfill(Object, arguments);
+};
 
-defineProperties(polyfill, {
+defineProperties(bound, {
 	getPolyfill: getPolyfill,
 	implementation: implementation,
 	shim: shim
 });
 
-module.exports = polyfill;
+module.exports = bound;

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
 	"main": "index.js",
 	"scripts": {
 		"pretest": "npm run --silent lint && es-shim-api --bound",
-		"test": "npm run --silent tests-only",
+		"test": "npm run --silent tests-only && npm run test:ses",
 		"posttest": "aud --production",
 		"tests-only": "npm run --silent test:implementation && npm run --silent test:shim",
-		"test:native": "node test/native.js",
-		"test:shim": "node test/shimmed.js",
-		"test:implementation": "node test/index.js",
+		"test:native": "node test/native",
+		"test:shim": "node test/shimmed",
+		"test:implementation": "node test",
+		"test:ses": "node test/ses-compat",
 		"coverage": "covert test/*.js",
 		"lint": "eslint .",
 		"build": "mkdir -p dist && browserify browserShim.js > dist/browser.js",
@@ -56,6 +57,7 @@
 		"has": "^1.0.3",
 		"is": "^3.3.0",
 		"safe-publish-latest": "^1.1.4",
+		"ses": "^0.10.3",
 		"tape": "^5.0.1"
 	},
 	"testling": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"license": "MIT",
 	"main": "index.js",
 	"scripts": {
-		"pretest": "npm run --silent lint && es-shim-api",
+		"pretest": "npm run --silent lint && es-shim-api --bound",
 		"test": "npm run --silent tests-only",
 		"posttest": "aud --production",
 		"tests-only": "npm run --silent test:implementation && npm run --silent test:shim",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	],
 	"dependencies": {
 		"define-properties": "^1.1.3",
-		"function-bind": "^1.1.1",
+		"es-abstract": "^1.18.0-next.0",
 		"has-symbols": "^1.0.1",
 		"object-keys": "^1.1.1"
 	},

--- a/test/ses-compat.js
+++ b/test/ses-compat.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// requiring ses exposes "lockdown" on the global
+require('ses');
+
+/*
+ * lockdown freezes the primordials
+ * disabling the error taming makes debugging much easier
+ * lockdown({ errorTaming: 'unsafe' });
+ */
+// eslint-disable-next-line no-undef
+lockdown();
+
+// initialize the module
+require('..');


### PR DESCRIPTION
the issue is that when `Object.assign` is present, this package appends additional properties to it, like `getPolyfill`. under SES, this has been hardened and you cannot append the properties